### PR TITLE
Add neuro scripts

### DIFF
--- a/scripts/neuro/01_setup.sh
+++ b/scripts/neuro/01_setup.sh
@@ -31,8 +31,8 @@ neuro config switch-cluster neuro-compute
 echo "Securely uploading bucket credentials"
 neuro secret add bucket-sa-key @${BUCKET_SA_KEY_FILE}
 
-echo "Uploading training code"
+echo "Uploading the project"
 neuro cp -ru . -T storage:yelp_dataset
 
-echo "Building training image"
-neuro-extras image build -f Dockerfile . image:yelp_dataset:v1.0
+#echo "Building training image"
+#neuro-extras image build -f Dockerfile . image:yelp_dataset:v1.0

--- a/scripts/neuro/01_setup.sh
+++ b/scripts/neuro/01_setup.sh
@@ -1,0 +1,38 @@
+#!/bin/env bash
+set -o xtrace
+
+# cd <project-root>
+[ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
+
+# Parse arguments
+for i in "$@"; do
+  case $i in
+    --bucket-sa-key-file=*)
+    BUCKET_SA_KEY_FILE="${i#*=}"
+    shift # past argument=value
+    ;;
+  esac
+done
+if [ ! "${BUCKET_SA_KEY_FILE}" ]; then
+  echo "Missing required argument: --bucket-sa-key-file=..."
+  exit 1
+fi
+
+# --
+
+echo "Installing Neu.ro platform clients"
+pip install -Uq neuro-cli neuro-extras
+
+echo "Logging in to the Neu.ro platform"
+neuro login  # register with email and get free 100h gpu
+neuro config switch-cluster neuro-compute
+
+
+echo "Securely uploading bucket credentials"
+neuro secret add bucket-sa-key @${BUCKET_SA_KEY_FILE}
+
+echo "Uploading training code"
+neuro cp -ru . -T storage:yelp_dataset
+
+echo "Building training image"
+neuro-extras image build -f Dockerfile . image:yelp_dataset:v1.0

--- a/scripts/neuro/02_gpu_jupyter.sh
+++ b/scripts/neuro/02_gpu_jupyter.sh
@@ -1,0 +1,29 @@
+#!/bin/env bash
+set -o xtrace
+
+# cd <project-root>
+[ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
+
+NAME=yelp-jupyter
+
+
+neuro run \
+  --name ${NAME} \
+  --preset gpu-small-p \
+  --life-span 8h \
+  --http 8888 \
+  --volume storage:yelp_dataset:/project:rw \
+  --volume secret:bucket-sa-key:/opt/developers-key.json \
+  --env GOOGLE_APPLICATION_CREDENTIALS=/opt/developers-key.json \
+  --env MLFLOW_TRACKING_URI=http://mlflow.lab1-team3.neu.ro:5000 \
+  --env PYTHONPATH=/project \
+  --detach \
+  image:yelp_dataset:v1.0 \
+  bash -euo pipefail -o xtrace -c '
+    pip install -Uq jupyter
+    jupyter notebook --no-browser --ip=0.0.0.0 --allow-root --NotebookApp.token= --notebook-dir=/project
+  '
+echo "========================================================================"
+echo "Jupyter is running, please don't forget to kill it: 'neuro kill ${NAME}'"
+echo "========================================================================"
+neuro logs ${NAME}

--- a/scripts/neuro/02_gpu_jupyter.sh
+++ b/scripts/neuro/02_gpu_jupyter.sh
@@ -22,11 +22,11 @@ neuro run \
   --detach \
   --life-span 8h \
   image:/artemyushkovskiy/yelp_dataset:v1.0 \
-  bash -euo pipefail -o xtrace -c '
+  bash -euo pipefail -c '
     pip install -Uq jupyter
     jupyter notebook --no-browser --ip=0.0.0.0 --allow-root --NotebookApp.token= --notebook-dir=/project
   '
 echo
-echo "Jupyter is running, please don't forget to kill it: 'neuro kill ${NAME}'"
+echo "Jupyter is running, please DO NOT FORGET TO KILL IT: 'neuro kill ${NAME}'"
 echo
 neuro logs ${NAME}

--- a/scripts/neuro/02_gpu_jupyter.sh
+++ b/scripts/neuro/02_gpu_jupyter.sh
@@ -4,9 +4,10 @@ set -o xtrace
 # cd <project-root>
 [ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
 
+echo "Uploading the project"
+neuro cp -ru . -T storage:yelp_dataset
+
 NAME=yelp-jupyter
-
-
 neuro run \
   --name ${NAME} \
   --preset gpu-small-p \
@@ -16,14 +17,16 @@ neuro run \
   --volume secret:bucket-sa-key:/opt/developers-key.json \
   --env GOOGLE_APPLICATION_CREDENTIALS=/opt/developers-key.json \
   --env MLFLOW_TRACKING_URI=http://mlflow.lab1-team3.neu.ro:5000 \
+  --env GIT_PYTHON_REFRESH=quiet \
   --env PYTHONPATH=/project \
   --detach \
-  image:yelp_dataset:v1.0 \
+  --life-span 8h \
+  image:/artemyushkovskiy/yelp_dataset:v1.0 \
   bash -euo pipefail -o xtrace -c '
     pip install -Uq jupyter
     jupyter notebook --no-browser --ip=0.0.0.0 --allow-root --NotebookApp.token= --notebook-dir=/project
   '
-echo "========================================================================"
+echo
 echo "Jupyter is running, please don't forget to kill it: 'neuro kill ${NAME}'"
-echo "========================================================================"
+echo
 neuro logs ${NAME}

--- a/scripts/neuro/03_gpu_server.sh
+++ b/scripts/neuro/03_gpu_server.sh
@@ -1,0 +1,23 @@
+#!/bin/env bash
+set -o xtrace
+
+# cd <project-root>
+[ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
+
+NAME=yelp-server
+
+
+neuro run \
+  --name ${NAME} \
+  --preset gpu-small-p \
+  --volume storage:yelp_dataset:/project:rw \
+  --env PYTHONPATH=/project \
+  --env GOOGLE_APPLICATION_CREDENTIALS=/project/developers-key.json \
+  --env MLFLOW_TRACKING_URI=http://mlflow.lab1-team3.neu.ro:5000 \
+  --detach \
+  image:yelp_dataset:v1.0 \
+  bash
+echo "======================================================================="
+echo "Server is running, please don't forget to kill it: 'neuro kill ${NAME}'"
+echo "======================================================================="
+neuro attach ${NAME}

--- a/scripts/neuro/03_gpu_server.sh
+++ b/scripts/neuro/03_gpu_server.sh
@@ -20,6 +20,6 @@ neuro run \
   image:/artemyushkovskiy/yelp_dataset:v1.0 \
   bash
 echo
-echo "Server is running, please don't forget to kill it: 'neuro kill ${NAME}'"
+echo "Server is running, please DO NOT FORGET TO KILL IT: 'neuro kill ${NAME}'"
 echo
 neuro attach ${NAME}

--- a/scripts/neuro/03_gpu_server.sh
+++ b/scripts/neuro/03_gpu_server.sh
@@ -4,9 +4,10 @@ set -o xtrace
 # cd <project-root>
 [ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
 
+echo "Uploading the project"
+neuro cp -ru . -T storage:yelp_dataset
+
 NAME=yelp-server
-
-
 neuro run \
   --name ${NAME} \
   --preset gpu-small-p \
@@ -14,10 +15,11 @@ neuro run \
   --env PYTHONPATH=/project \
   --env GOOGLE_APPLICATION_CREDENTIALS=/project/developers-key.json \
   --env MLFLOW_TRACKING_URI=http://mlflow.lab1-team3.neu.ro:5000 \
+  --env GIT_PYTHON_REFRESH=quiet \
   --detach \
-  image:yelp_dataset:v1.0 \
+  image:/artemyushkovskiy/yelp_dataset:v1.0 \
   bash
-echo "======================================================================="
+echo
 echo "Server is running, please don't forget to kill it: 'neuro kill ${NAME}'"
-echo "======================================================================="
+echo
 neuro attach ${NAME}

--- a/scripts/neuro/04_gpu_train.sh
+++ b/scripts/neuro/04_gpu_train.sh
@@ -1,0 +1,23 @@
+#!/bin/env bash
+set -o xtrace
+
+# cd <project-root>
+[ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
+
+NAME=yelp-server
+TRAIN_SCRIPT=src/train_average_embedding.py
+
+neuro run \
+  --name ${NAME} \
+  --preset gpu-small-p \
+  --volume storage:yelp_dataset:/project:rw \
+  --env PYTHONPATH=/project \
+  --env GOOGLE_APPLICATION_CREDENTIALS=/project/developers-key.json \
+  --env MLFLOW_TRACKING_URI=http://mlflow.lab1-team3.neu.ro:5000 \
+  --detach \
+  image:yelp_dataset:v1.0 \
+  python -u /project/${TRAIN_SCRIPT}
+echo "======================================================================="
+echo "Server is running, please don't forget to kill it: 'neuro kill ${NAME}'"
+echo "======================================================================="
+neuro logs ${NAME}

--- a/scripts/neuro/04_gpu_train.sh
+++ b/scripts/neuro/04_gpu_train.sh
@@ -20,6 +20,6 @@ neuro run \
   image:/artemyushkovskiy/yelp_dataset:v1.0 \
   mlflow run /project --no-conda
 echo
-echo "Server is running, please don't forget to kill it: 'neuro kill ${NAME}'"
+echo "Server is running, please DO NOT FORGET TO KILL IT: 'neuro kill ${NAME}'"
 echo
 neuro logs ${NAME}

--- a/scripts/neuro/04_gpu_train.sh
+++ b/scripts/neuro/04_gpu_train.sh
@@ -4,9 +4,10 @@ set -o xtrace
 # cd <project-root>
 [ -d "./src" ] || { echo "Must run from the project root!"; exit 1  ;}
 
-NAME=yelp-server
-TRAIN_SCRIPT=src/train_average_embedding.py
+echo "Uploading the project"
+neuro cp -ru . -T storage:yelp_dataset
 
+NAME=yelp-train
 neuro run \
   --name ${NAME} \
   --preset gpu-small-p \
@@ -14,10 +15,11 @@ neuro run \
   --env PYTHONPATH=/project \
   --env GOOGLE_APPLICATION_CREDENTIALS=/project/developers-key.json \
   --env MLFLOW_TRACKING_URI=http://mlflow.lab1-team3.neu.ro:5000 \
+  --env GIT_PYTHON_REFRESH=quiet \
   --detach \
-  image:yelp_dataset:v1.0 \
-  python -u /project/${TRAIN_SCRIPT}
-echo "======================================================================="
+  image:/artemyushkovskiy/yelp_dataset:v1.0 \
+  mlflow run /project --no-conda
+echo
 echo "Server is running, please don't forget to kill it: 'neuro kill ${NAME}'"
-echo "======================================================================="
+echo
 neuro logs ${NAME}


### PR DESCRIPTION
Add scripts to run training on Neu.ro platform:
```
scripts
└── neuro
    ├── 01_setup.sh             # install CLI, login
    ├── 02_gpu_jupyter.sh   # run colab-like jupyter
    ├── 03_gpu_server.sh    # run ssh-like server
    └── 04_gpu_train.sh      # run training that will push artifacts to MLflow server
```
Run e.g. `sh scripts/neuro/01_setup.sh`